### PR TITLE
feat(profile): add user profile modal

### DIFF
--- a/app/(dashboard)/_components/user-menu.tsx
+++ b/app/(dashboard)/_components/user-menu.tsx
@@ -13,11 +13,12 @@ import { useSession } from "next-auth/react"
 import { LogOut, User, LogIn } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useSignInModal } from "@/store/use-signin-modal"
-import { toast } from "sonner"
+import { useProfileModal } from "@/store/use-profile-modal"
 
 export function UserMenu() {
   const { data: session } = useSession()
   const { open: openSignInModal } = useSignInModal()
+  const { open: openProfileModal } = useProfileModal()
   
   if (!session?.user) {
     return (
@@ -65,11 +66,7 @@ export function UserMenu() {
         <DropdownMenuSeparator />
         <DropdownMenuItem 
           className="cursor-pointer"
-          onClick={() => {
-            toast.info("Profile settings coming soon!", {
-              description: "We're working on adding profile management features."
-            })
-          }}
+          onClick={openProfileModal}
         >
           <User className="mr-2 h-4 w-4" />
           Profile

--- a/components/modals/profile-modal.tsx
+++ b/components/modals/profile-modal.tsx
@@ -1,0 +1,113 @@
+/**
+ * Profile modal component
+ * Shows user profile information in a modal
+ */
+
+'use client'
+
+import { useSession } from 'next-auth/react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { useProfileModal } from '@/store/use-profile-modal'
+import { GoogleIcon, GitHubIcon } from '@/components/ui/icons'
+import { Calendar, Clock, Mail } from 'lucide-react'
+
+export function ProfileModal() {
+  const { isOpen, close } = useProfileModal()
+  const { data: session } = useSession()
+
+  if (!session?.user) return null
+
+  // Format date for display
+  const formatDate = (date: Date | string | undefined) => {
+    if (!date) return 'N/A'
+    return new Date(date).toLocaleDateString('en-US', {
+      month: 'long',
+      year: 'numeric'
+    })
+  }
+
+  // Get real user data from session
+  const memberSince = session.user.createdAt
+  const providers = session.user.providers || []
+
+  return (
+    <Dialog open={isOpen} onOpenChange={close}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Profile</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          {/* User Info Section */}
+          <div className="flex items-center space-x-4">
+            <Avatar className="h-20 w-20">
+              <AvatarImage src={session.user.image || ''} />
+              <AvatarFallback className="text-2xl">
+                {session.user.name?.[0] || session.user.email?.[0] || 'U'}
+              </AvatarFallback>
+            </Avatar>
+            <div className="space-y-1">
+              <h3 className="text-xl font-semibold">{session.user.name || 'User'}</h3>
+              <p className="text-sm text-muted-foreground">{session.user.email}</p>
+              <div className="flex items-center text-xs text-muted-foreground">
+                <Calendar className="mr-1 h-3 w-3" />
+                Member since {formatDate(memberSince)}
+              </div>
+            </div>
+          </div>
+
+          {/* Account Information Section */}
+          <div className="space-y-4">
+            <div>
+              <h4 className="text-sm font-medium mb-3">Account Information</h4>
+              <div className="space-y-2">
+                <div className="flex items-center text-sm">
+                  <Mail className="mr-2 h-4 w-4 text-muted-foreground" />
+                  <span className="text-muted-foreground">Email:</span>
+                  <span className="ml-2">{session.user.email}</span>
+                </div>
+
+                <div className="flex items-center text-sm">
+                  <span className="text-muted-foreground mr-2">Connected:</span>
+                  <div className="flex gap-2">
+                    {providers.includes('google') && (
+                      <Badge variant="secondary" className="flex items-center gap-1">
+                        <GoogleIcon className="h-3 w-3" />
+                        Google
+                      </Badge>
+                    )}
+                    {providers.includes('github') && (
+                      <Badge variant="secondary" className="flex items-center gap-1">
+                        <GitHubIcon className="h-3 w-3" />
+                        GitHub
+                      </Badge>
+                    )}
+                    {providers.includes('resend') && (
+                      <Badge variant="secondary" className="flex items-center gap-1">
+                        <Mail className="h-3 w-3" />
+                        Email
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex items-center text-sm">
+                  <Clock className="mr-2 h-4 w-4 text-muted-foreground" />
+                  <span className="text-muted-foreground">Last login:</span>
+                  <span className="ml-2">Just now</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/docs/PROFILE_MODAL_PR.md
+++ b/docs/PROFILE_MODAL_PR.md
@@ -1,0 +1,33 @@
+# Profile Modal Feature
+
+## Overview
+Adds a profile modal that displays user information when clicking the "Profile" option in the user menu.
+
+## Changes
+- Created `use-profile-modal` store for modal state management
+- Added `ProfileModal` component with user information display
+- Updated `UserMenu` to open profile modal instead of showing toast
+- Added `ProfileModal` to `ModalProvider`
+
+## UI Display
+The modal shows:
+- User avatar, name, and email
+- Real member since date from database
+- Connected accounts (Google/GitHub/Email) from auth providers
+- Always shows "Just now" for last login (since user is currently logged in)
+
+## Files Changed
+- `store/use-profile-modal.ts` - New modal state store
+- `components/modals/profile-modal.tsx` - New profile modal component
+- `app/(dashboard)/_components/user-menu.tsx` - Updated to open modal
+- `providers/modal-provider.tsx` - Added ProfileModal
+- `auth.ts` - Added session callback to fetch user data
+- `types/next-auth.d.ts` - Extended session types
+- `components/ui/badge.tsx` - Added badge component for provider display
+
+## Testing
+1. Log in to the application
+2. Click on your avatar in the top right
+3. Click "Profile" in the dropdown
+4. Verify the modal displays your user information correctly
+5. Verify the modal can be closed

--- a/providers/modal-provider.tsx
+++ b/providers/modal-provider.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 
 import { RenameModal } from '@/components/modals/rename-modal'
 import { SignInModal } from '@/components/modals/signin-modal'
+import { ProfileModal } from '@/components/modals/profile-modal'
 import { useSignInModal } from '@/store/use-signin-modal'
 
 export const ModalProvider = () => {
@@ -20,6 +21,7 @@ export const ModalProvider = () => {
     <>
       <RenameModal />
       <SignInModal showSignInModal={isOpen} setShowSignInModal={close} />
+      <ProfileModal />
     </>
   )
 }

--- a/store/use-profile-modal.ts
+++ b/store/use-profile-modal.ts
@@ -1,0 +1,19 @@
+/**
+ * Profile modal state management
+ */
+
+'use client'
+
+import { create } from 'zustand'
+
+interface ProfileModalStore {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+}
+
+export const useProfileModal = create<ProfileModalStore>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}))

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -5,7 +5,14 @@ declare module "next-auth" {
   interface Session {
     user: {
       id: string
+      createdAt?: Date
+      providers?: string[]
     } & DefaultSession["user"]
+  }
+  
+  interface User {
+    id: string
+    createdAt?: Date
   }
 }
 


### PR DESCRIPTION
- Create profile modal with user information display
- Add Zustand store for profile modal state management
- Extend NextAuth session to include user creation date and providers
- Add badge component for displaying connected accounts
- Show real member since date and connected auth providers

🤖 Generated with [Claude Code](https://claude.ai/code)